### PR TITLE
Puppet 4 changes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,8 +5,8 @@ class slack (
   $slack_channel        = '#puppet',
   $slack_botname        = 'puppet',
   $slack_puppet_reports = undef,
-  $slack_puppet_dir     = '/etc/puppet',
-  $is_puppetmaster      = true,
+  $slack_puppet_dir     = '/etc/puppetlabs/puppet',
+  $is_puppetmaster      = false,
 ) {
 
   anchor {'slack::begin':}
@@ -23,7 +23,7 @@ class slack (
     case $::osfamily {
       'redhat','debian': {
         check_run::task { 'task_faraday_gem_install':
-          exec_command => '/usr/bin/puppetserver gem install faraday',
+          exec_command => '/opt/puppetlabs/bin/puppetserver gem install faraday',
           require      => Anchor['slack::begin'],
           before       => File["${slack_puppet_dir}/slack.yaml"],
         }


### PR DESCRIPTION
With the distribution of Puppet 4 the directories have been modified for OS and PE versions.
/etc/puppetlabs/puppet is now the puppet_dir regardless of which you are running.
/opt/puppetlabs/bin is where the binaries are located (well /opt/puppetlabs/puppet/bin/puppet but the main bin is for the common binaries)
Also if using puppet 4 your master would be running puppet 4 as well so therefore wouldn't use gem provider to install faraday so setting "is_puppetmaster" default to false
